### PR TITLE
Kiali extension updates

### DIFF
--- a/extensions/kiali/.gitignore
+++ b/extensions/kiali/.gitignore
@@ -1,0 +1,1 @@
+skupper-kiali-bridge

--- a/extensions/kiali/Makefile
+++ b/extensions/kiali/Makefile
@@ -1,0 +1,21 @@
+QUAY_ORG ?= ckruse
+
+IMAGE_NAME ?= quay.io/${QUAY_ORG}/skupper-kiali-bridge:latest
+
+build:
+	docker build . -t ${IMAGE_NAME}
+
+push:
+	docker push ${IMAGE_NAME}
+
+.ensure-namespace:
+	@if [ -z "${NAMESPACE}" ]; then echo "NAMESPACE env var is not set. Aborting."; exit 1; fi
+
+deploy: .ensure-namespace
+	@cat ./deployment.yaml | IMAGE_NAME="${IMAGE_NAME}" NAMESPACE=${NAMESPACE} envsubst | kubectl apply -n ${NAMESPACE} -f -
+
+undeploy: .ensure-namespace
+	@cat ./deployment.yaml | IMAGE_NAME="${IMAGE_NAME}" NAMESPACE=${NAMESPACE} envsubst | kubectl delete -n ${NAMESPACE} -f -
+
+go-build:
+	go build

--- a/extensions/kiali/README.md
+++ b/extensions/kiali/README.md
@@ -39,7 +39,7 @@ A shared set of labels present on each metric.
 
 ### Not Implemented
 
-* `security`: this is something we _could_ probably find a way to add in
+* `secure`: this is something we _could_ probably find a way to add in
   listener/connector records. So far I don't think it has came up organically.
 * `flags`
 

--- a/extensions/kiali/deployment.yaml
+++ b/extensions/kiali/deployment.yaml
@@ -19,7 +19,7 @@ spec:
         app: skupper-kiali-bridge
     spec:
       containers:
-      - image: quay.io/ckruse/skupper-kiali-bridge:latest
+      - image: ${IMAGE_NAME}
         imagePullPolicy: Always
         name: main
         securityContext:

--- a/extensions/kiali/main.go
+++ b/extensions/kiali/main.go
@@ -30,7 +30,7 @@ func init() {
 `, os.Args[0])
 		flags.PrintDefaults()
 	}
-	flags.BoolVar(&Debug, "debug", false, "enalbe debug logging")
+	flags.BoolVar(&Debug, "debug", false, "enable debug logging")
 	flags.BoolVar(&MetricsEnabled, "metrics", true, "enables kiali metrics")
 	flags.StringVar(&ExtensionName, "extension", "skupper", "sets the extension name")
 	flags.StringVar(&MessagingConfig, "messaging-config", "", "path to a skupper connect.json")


### PR DESCRIPTION
1. Changes "security" to "secure", which is now a boolean, not a string.
2. The source name should be the deployment name, not a pod name.
3. Fixes a typo in main help text.
4. Remove the obsolete executable.
5. Adds a Makefile with the following targets: 
  **build**: performs the docker build
  **push**: pushes the image to quay.io (set QUAY_ORG for your own organization)
  **deploy**: creates the resources in your k8s cluster (set NAMESPACE to tell it where to put it; set QUAY_ORG if the image is somewhere custom)
  **undeploy**: remove the resources from your k8s cluster (set NAMESPACE to tell it where it already is)
  **go-build**: builds the go executable on your local machine